### PR TITLE
Fix timestamp handling in summarizer

### DIFF
--- a/utils/summarizer.js
+++ b/utils/summarizer.js
@@ -23,7 +23,8 @@ async function summarizeConversation(messages) {
     const summaryMessage = {
       text: `Summary: ${summary}`,
       isUser: false,
-      timestamp: new Date()
+      // Use ISO string to match the timestamp format of other messages
+      timestamp: new Date().toISOString()
     };
     // Keep last 2 messages to maintain recent context
     return [summaryMessage, ...messages.slice(-2)];


### PR DESCRIPTION
## Summary
- ensure the summarizer stores timestamps in ISO string format

## Testing
- `node -c utils/summarizer.js`
- `node -c controllers/geminiController.cjs`


------
https://chatgpt.com/codex/tasks/task_e_6857e8070c34832bab5fd6496cd9254d