### PR TITLE
Fix PID file write method

### DIFF
--- a/server.cjs
+++ b/server.cjs
@@ -62,7 +62,7 @@ app.use((req, res) => {
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);
   // Save PID to file
-  fs.writeFileSync('server.pid', pid.toString(), (err) => {
+  fs.writeFile('server.pid', pid.toString(), err => {
     if (err) console.error('Error writing PID to server.pid:', err);
   });
 });


### PR DESCRIPTION
## Summary
- use `fs.writeFile` for saving the server PID

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857f2965568832ba989b4e6a4a99cea