### PR TITLE
Add thread listing endpoints and ensure clean merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 nohup.out
 server.pid
-controllers/offene_fragen.txt
+ai_fragen/offene_fragen.txt
 chatbot.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# HTC ABC AI Bot
+
+This project provides a simple Node.js server that exposes an API endpoint for answering questions using the Gemini API.
+
+## Environment Setup
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+   Ensure that Node.js (version 18 or newer) and npm are available on your machine.
+
+2. **Configuration**
+   Create a `.env` file in the project root containing the API key for the Gemini API and an optional port:
+   ```env
+   API_KEY=your-google-api-key
+   PORT=3000 # optional, defaults to 3000
+   ```
+
+## Running `server.cjs`
+
+Start the application with:
+```bash
+node server.cjs
+```
+Alternatively you can run `npm start`. When running on systems like all-inkl.com you may want to start the process in the background:
+```bash
+nohup node server.cjs &
+```
+The server writes its process id to `server.pid` so you can stop it using:
+```bash
+kill -9 $(cat server.pid)
+```
+
+The server listens on `/api/chat` for POST requests and serves the static files from the `public` directory.
+
+## Handling Unanswered Questions
+
+If the Gemini API responds with
+"Diese Frage kann basierend auf den bereitgestellten Informationen nicht beantwortet werden",
+this question is logged to `ai_fragen/offene_fragen.txt` for later review.
+The log entry includes a timestamp and the original prompt.

--- a/controllers/geminiController.cjs
+++ b/controllers/geminiController.cjs
@@ -168,4 +168,4 @@ async function generateResponse(req, res) {
   }
 }
 
-module.exports = { generateResponse };
+module.exports = { generateResponse, Conversation };

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Unbeantwortete Fragen</title>
+  <script defer src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-6 font-sans">
+  <h1 class="text-2xl font-bold mb-4">Unbeantwortete Fragen</h1>
+  <ul id="questions" class="space-y-4"></ul>
+
+  <script>
+  async function load() {
+    const list = document.getElementById('questions');
+    list.innerHTML = '';
+    try {
+      const res = await fetch('/api/unanswered');
+      const questions = await res.json();
+      if (!Array.isArray(questions)) return;
+      questions.forEach(q => {
+        const li = document.createElement('li');
+        li.className = 'border p-4 rounded';
+        const form = document.createElement('form');
+        form.innerHTML = `
+          <p class="mb-2 font-medium">${q}</p>
+          <input type="hidden" name="question" value="${q}">
+          <input name="answer" class="border p-2 w-full mb-2" placeholder="Antwort" required>
+          <button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Senden</button>
+        `;
+        form.addEventListener('submit', async e => {
+          e.preventDefault();
+          const data = {
+            question: q,
+            answer: form.answer.value
+          };
+          const resp = await fetch('/api/answer', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(data)
+          });
+          if (resp.ok) li.remove();
+        });
+        li.appendChild(form);
+        list.appendChild(li);
+      });
+    } catch (err) {
+      list.innerHTML = '<li>Fehler beim Laden</li>';
+      console.error(err);
+    }
+  }
+  load();
+  </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -8,52 +8,8 @@
   <title>HTW Dresden AI Chat Assistant</title>
   <script defer src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous">
-  <style>
-    /* Theme Variables */
-[data-theme="light"] { --bg: #f8fafc; --fg: #1f2937; --border: #e5e7eb; --accent: #3b82f6; }
-[data-theme="dark"]  { --bg: #1a1a2e; --fg: #f3f4f6; --border: #374151; --accent: #3b82f6; }
-* { box-sizing: border-box; }
-body { margin: 0; height: 100vh; display: grid; grid-template-rows: auto 1fr auto; background: var(--bg); color: var(--fg); font-family: 'Inter', sans-serif; }
-header { grid-row: 1; display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; background: var(--accent); color: white; }
-header h1 { font-size: 1.5rem; font-weight: 600; margin: 0; }
-.actions { display: flex; gap: 1rem; align-items: center; }
-.actions button { background: transparent; border: none; color: white; font-size: 1.25rem; cursor: pointer; transition: transform .2s; }
-.actions button:hover { transform: scale(1.1); }
-#main { grid-row: 2; display: grid; grid-template-columns: 300px 1fr; height: 100%; overflow: hidden; }
-@media (max-width: 768px) { #main { grid-template-columns: 1fr; } }
-#threads { background: var(--bg); border-right: 1px solid var(--border); padding: 1rem; overflow-y: auto; }
-#threads h2 { margin: 0 0 1rem; font-size: 1.125rem; font-weight: 500; }
-.thread { display: flex; justify-content: space-between; align-items: center; padding: .75rem 1rem; border-radius: .75rem; cursor: pointer; transition: background .2s, color .2s; }
-.thread.active, .thread:hover { background: var(--accent); color: white; }
-@media (max-width: 768px) { #threads { display: none; } }
-#chat { display: flex; flex-direction: column; background: var(--bg); position: relative; height: 100%; min-height: 0; }
-#messages { flex: 1 1 auto; overflow-y: auto; padding: 1.5rem; display: flex; flex-direction: column; gap: 1rem; scroll-behavior: smooth; min-height: 0; }
-.message { position: relative; max-width: 70%; padding: 1rem 1.25rem; border-radius: 1rem; line-height: 1.5; background: var(--border); transition: transform .2s; }
-.message:hover { transform: translateY(-2px); }
-.message.user { margin-left: auto; background: var(--accent); color: white; border-bottom-right-radius: .25rem; }
-.message.ai { margin-right: auto; background: var(--bg); border: 1px solid var(--border); color: var(--fg); border-bottom-left-radius: .25rem; }
-.metadata { font-size: .75rem; opacity: .6; margin-top: .5rem; text-align: right; }
-.copy-btn { position: absolute; top: .5rem; right: .5rem; opacity: .4; cursor: pointer; transition: opacity .2s; }
-.copy-btn:hover { opacity: 1; }
-#typing { display: none; align-items: center; padding: .75rem 1.5rem; }
-.dot { width: 8px; height: 8px; background: var(--accent); border-radius: 50%; margin: 0 4px; animation: bounce 1.2s infinite; }
-.dot:nth-child(2) { animation-delay: .2s; }
-.dot:nth-child(3) { animation-delay: .4s; }
-@keyframes bounce { 0%, 80%, 100% { transform: translateY(0); } 40% { transform: translateY(-6px); } }
-#scroll-btn { position: fixed; bottom: 3rem; right: 2rem; background: var(--accent); color: white; border: none; border-radius: 50%; padding: .75rem; cursor: pointer; display: none; box-shadow: 0 2px 6px rgba(0,0,0,0.2); transition: transform .2s; }
-#scroll-btn:hover { transform: scale(1.1); }
-#input { grid-row: 3; background: var(--bg); border-top: 1px solid var(--border); padding: 1rem 2rem; }
-@media (max-width: 768px) { #input { padding: .75rem 1rem; } }
-.wrapper { max-width: 900px; margin: 0 auto; display: flex; gap: .75rem; align-items: center; }
-@media (max-width: 768px) { .wrapper { flex-direction: column; align-items: stretch; gap: .5rem; } }
-#chat-input { flex: 1; padding: .75rem 1rem; border: 1px solid var(--border); border-radius: .75rem; resize: none; min-height: 2.5rem; font-size: .95rem; }
-button.send { background: var(--accent); color: white; padding: .75rem 1.5rem; border: none; border-radius: .75rem; cursor: pointer; font-weight: 500; transition: transform .2s; }
-button.send:hover { transform: translateY(-2px); }
-.suggest { display: flex; justify-content: center; gap: .5rem; margin-top: .75rem; flex-wrap: wrap; }
-.chip { background: var(--border); padding: .5rem 1rem; border-radius: 9999px; cursor: pointer; transition: transform .2s; }
-.chip:hover { background: var(--accent); color: white; transform: scale(1.05); }
-  </style>
 </head>
 <body>
   <header>
@@ -61,7 +17,7 @@ button.send:hover { transform: translateY(-2px); }
     <div class="actions">
       <button id="theme-toggle" title="Theme wechseln"><i class="fas fa-adjust"></i></button>
       <span id="current-time"></span>
-      <button id="new-chat" title="Neues Gespräch"><i class="fas fa-plus"></i></button>
+      <button id="new-chat" title="Neues Gespräch"><i class="fas fa-plus"></i></button> <button id="settings-btn" title="Einstellungen"><i class="fas fa-cog"></i></button>
     </div>
   </header>
   <div id="main">
@@ -86,6 +42,13 @@ button.send:hover { transform: translateY(-2px); }
     </div>
   </div>
   <button id="scroll-btn" title="Zum neuesten springen"><i class="fas fa-arrow-down"></i></button>
+  <div id="settings-modal">
+    <div class="modal-content">
+      <h3 class="mb-2 font-medium">Einstellungen</h3>
+      <label class="block mb-2">Akzentfarbe: <input type="color" id="accent-color"></label>
+      <button id="close-settings" class="send mt-2">Schließen</button>
+    </div>
+  </div>
   <script>
     const root = document.documentElement;
     const themeToggle = document.getElementById('theme-toggle');
@@ -99,6 +62,10 @@ button.send:hover { transform: translateY(-2px); }
     const suggestionChips = document.querySelectorAll('.chip');
     let conversationId = null;
 
+    const settingsBtn = document.getElementById("settings-btn");
+    const settingsModal = document.getElementById("settings-modal");
+    const closeSettings = document.getElementById("close-settings");
+    const accentColorInput = document.getElementById("accent-color");
     // Update clock every minute
     function updateClock() {
       currentTimeEl.textContent = new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
@@ -116,6 +83,18 @@ button.send:hover { transform: translateY(-2px); }
     if (saved) root.setAttribute('data-theme', saved);
 
     // Scroll handling
+    const savedAccent = localStorage.getItem("accent");
+    if (savedAccent) {
+      root.style.setProperty("--accent", savedAccent);
+      accentColorInput.value = savedAccent;
+    }
+    settingsBtn.addEventListener("click", () => settingsModal.classList.add("open"));
+    closeSettings.addEventListener("click", () => settingsModal.classList.remove("open"));
+    settingsModal.addEventListener("click", e => { if (e.target === settingsModal) settingsModal.classList.remove("open"); });
+    accentColorInput.addEventListener("input", () => {
+      root.style.setProperty("--accent", accentColorInput.value);
+      localStorage.setItem("accent", accentColorInput.value);
+    });
     function scrollToBottom() {
       scrollBtnEl.style.display = 'none';
       messagesEl.scrollTop = messagesEl.scrollHeight;
@@ -136,18 +115,30 @@ button.send:hover { transform: translateY(-2px); }
     function addMsg(text, isUser, timestamp, copyable = false) {
       const m = document.createElement('div');
       m.className = `message ${isUser ? 'user' : 'ai'}`;
-      m.innerHTML = `<div>${text}</div>`;
+
+      const avatar = document.createElement('div');
+      avatar.className = 'avatar';
+      avatar.innerHTML = `<i class="fas ${isUser ? 'fa-user' : 'fa-robot'}"></i>`;
+      m.appendChild(avatar);
+
+      const bubble = document.createElement('div');
+      bubble.className = 'bubble';
+      bubble.innerHTML = text;
+
       if (!isUser && copyable) {
         const c = document.createElement('span');
         c.className = 'copy-btn';
         c.innerHTML = '<i class="fas fa-copy"></i>';
         c.addEventListener('click', () => navigator.clipboard.writeText(text));
-        m.appendChild(c);
+        bubble.appendChild(c);
       }
+
       const md = document.createElement('div');
       md.className = 'metadata';
       md.textContent = new Date(timestamp).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
-      m.appendChild(md);
+      bubble.appendChild(md);
+
+      m.appendChild(bubble);
       messagesEl.appendChild(m);
       scrollToBottom();
     }
@@ -155,7 +146,7 @@ button.send:hover { transform: translateY(-2px); }
     // Load conversation threads
     async function loadThreads() {
       try {
-        const res = await fetch('https://dev.olomek.com/api/threads');
+        const res = await fetch('/api/threads');
         const threads = await res.json();
         threadsEl.innerHTML = '<h2>Unterhaltungen</h2>';
         threads.forEach(thread => {
@@ -178,7 +169,7 @@ button.send:hover { transform: translateY(-2px); }
       document.querySelectorAll('.thread').forEach(t => t.classList.remove('active'));
       document.querySelector(`.thread[data-conversation-id="${id}"]`).classList.add('active');
       try {
-        const res = await fetch(`https://dev.olomek.com/api/threads/${id}`);
+        const res = await fetch(`/api/threads/${id}`);
         const conversation = await res.json();
         conversation.messages.forEach(msg => {
           addMsg(msg.text, msg.isUser, msg.timestamp, !msg.isUser);
@@ -214,7 +205,7 @@ button.send:hover { transform: translateY(-2px); }
       sendBtnEl.disabled = true;
       typingEl.style.display = 'flex';
       try {
-        const res = await fetch('https://dev.olomek.com/api/chat', {
+        const res = await fetch('/api/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ prompt: txt, conversationId })

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,267 @@
+/* Global theme variables */
+[data-theme="light"] {
+  --bg: #f8fafc;
+  --fg: #1f2937;
+  --border: #e5e7eb;
+  --accent: #3b82f6;
+}
+[data-theme="dark"] {
+  --bg: #1a1a2e;
+  --fg: #f3f4f6;
+  --border: #374151;
+  --accent: #3b82f6;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  background: var(--bg);
+  background-image: radial-gradient(circle at 0 0, rgba(0,0,0,0.05), transparent 70%);
+  color: var(--fg);
+  font-family: 'Inter', sans-serif;
+}
+header {
+  grid-row: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: linear-gradient(90deg, var(--accent), #8b5cf6);
+  color: white;
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: saturate(180%) blur(10px);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+}
+header h1 { font-size: 1.5rem; font-weight: 600; margin: 0; }
+.actions { display: flex; gap: 1rem; align-items: center; }
+.actions button {
+  background: transparent;
+  border: none;
+  color: white;
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: transform .2s;
+}
+.actions button:hover { transform: scale(1.1); }
+#main {
+  grid-row: 2;
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  height: 100%;
+  overflow: hidden;
+}
+@media (max-width: 768px) { #main { grid-template-columns: 1fr; } }
+#threads {
+  background: var(--bg);
+  border-right: 1px solid var(--border);
+  padding: 1rem;
+  overflow-y: auto;
+}
+#threads h2 { margin: 0 0 1rem; font-size: 1.125rem; font-weight: 500; }
+.thread {
+  padding: .75rem 1rem;
+  border-radius: .75rem;
+  cursor: pointer;
+  transition: background .2s, color .2s, box-shadow .2s;
+}
+.thread.active,
+.thread:hover {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+@media (max-width: 768px) { #threads { display: none; } }
+#chat {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  position: relative;
+  height: 100%;
+  min-height: 0;
+}
+#messages {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  scroll-behavior: smooth;
+  min-height: 0;
+}
+.message {
+  display: flex;
+  align-items: flex-end;
+  gap: .5rem;
+  max-width: 75%;
+  animation: fadeIn .3s ease;
+}
+.message.user { margin-left: auto; flex-direction: row-reverse; }
+.bubble {
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  line-height: 1.5;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+.message.user .bubble {
+  background: var(--accent);
+  color: white;
+  border-bottom-right-radius: .25rem;
+}
+.message.ai .bubble {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  border-bottom-left-radius: .25rem;
+}
+.avatar {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), #8b5cf6);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+.metadata {
+  font-size: .75rem;
+  opacity: .6;
+  margin-top: .25rem;
+  text-align: right;
+  font-style: italic;
+}
+.copy-btn {
+  position: absolute;
+  top: .5rem;
+  right: .5rem;
+  opacity: .4;
+  cursor: pointer;
+  transition: opacity .2s;
+}
+.copy-btn:hover { opacity: 1; }
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+#typing { display: none; align-items: center; padding: .75rem 1.5rem; }
+.dot {
+  width: 8px;
+  height: 8px;
+  background: var(--accent);
+  border-radius: 50%;
+  margin: 0 4px;
+  animation: bounce 1.2s infinite;
+}
+.dot:nth-child(2) { animation-delay: .2s; }
+.dot:nth-child(3) { animation-delay: .4s; }
+@keyframes bounce { 0%, 80%, 100% { transform: translateY(0); } 40% { transform: translateY(-6px); } }
+#scroll-btn {
+  position: fixed;
+  bottom: 3rem;
+  right: 2rem;
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  padding: .75rem;
+  cursor: pointer;
+  display: none;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  transition: transform .2s;
+}
+#scroll-btn:hover { transform: scale(1.1); }
+#input {
+  grid-row: 3;
+  background: var(--bg);
+  border-top: 1px solid var(--border);
+  padding: 1rem 2rem;
+}
+@media (max-width: 768px) { #input { padding: .75rem 1rem; } }
+.wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  gap: .75rem;
+  align-items: center;
+}
+@media (max-width: 768px) { .wrapper { flex-direction: column; align-items: stretch; gap: .5rem; } }
+#chat-input {
+  flex: 1;
+  padding: .75rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: .75rem;
+  resize: none;
+  min-height: 2.5rem;
+  font-size: .95rem;
+}
+button.send {
+  background: linear-gradient(90deg, var(--accent), #8b5cf6);
+  color: white;
+  padding: .75rem 1.5rem;
+  border: none;
+  border-radius: .75rem;
+  cursor: pointer;
+  font-weight: 500;
+  transition: transform .2s, box-shadow .2s;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+button.send:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+}
+.suggest {
+  display: flex;
+  justify-content: center;
+  gap: .5rem;
+  margin-top: .75rem;
+  flex-wrap: wrap;
+}
+.chip {
+  background: var(--border);
+  padding: .5rem 1rem;
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: transform .2s;
+}
+.chip:hover { background: var(--accent); color: white; transform: scale(1.05); }
+
+/* Scrollbar styling */
+#messages::-webkit-scrollbar {
+  width: 8px;
+}
+#messages::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+#messages::-webkit-scrollbar-thumb:hover {
+  background: var(--accent);
+}
+#messages {
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent) var(--border);
+}
+
+/* Modal styling */
+#settings-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+#settings-modal.open { display: flex; }
+.modal-content {
+  background: var(--bg);
+  color: var(--fg);
+  padding: 1.5rem;
+  border-radius: .75rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}

--- a/server.cjs
+++ b/server.cjs
@@ -9,7 +9,7 @@ const fs = require('fs');
 const express = require("express");
 const dotenv = require("dotenv");
 const bodyParser = require("body-parser");
-const { generateResponse } = require("./controllers/geminiController.cjs");
+const { generateResponse, Conversation } = require("./controllers/geminiController.cjs");
 const path = require('path');
 
 const pid = process.pid;
@@ -40,9 +40,93 @@ app.use((req, res, next) => {
   next();
 });
 
-
 // Routes
 app.post("/api/chat", generateResponse);
+
+// List all stored conversation threads
+app.get("/api/threads", async (req, res) => {
+  try {
+    const conversations = await Conversation.findAll({
+      attributes: ['conversationId', 'createdAt'],
+      order: [['createdAt', 'DESC']]
+    });
+    const threads = conversations.map(c => ({
+      conversationId: c.conversationId,
+      createdAt: c.createdAt
+    }));
+    res.json(threads);
+  } catch (err) {
+    console.error('Failed to fetch threads:', err.message);
+    res.status(500).json({ error: 'Unable to fetch threads' });
+  }
+});
+
+// Fetch messages for a specific conversation
+app.get("/api/threads/:id", async (req, res) => {
+  try {
+    const convo = await Conversation.findOne({ where: { conversationId: req.params.id } });
+    if (!convo) {
+      return res.status(404).json({ error: 'Conversation not found' });
+    }
+    res.json({ conversationId: convo.conversationId, messages: convo.messages });
+  } catch (err) {
+    console.error('Failed to fetch conversation:', err.message);
+    res.status(500).json({ error: 'Unable to fetch conversation' });
+  }
+});
+
+// Return list of unanswered questions
+app.get('/api/unanswered', async (req, res) => {
+  try {
+    const file = path.resolve(__dirname, 'ai_fragen/offene_fragen.txt');
+    const data = await fs.promises.readFile(file, 'utf8');
+    const questions = data
+      .split(/\n+/)
+      .filter(Boolean)
+      .map(line => {
+        const match = line.match(/Frage:\s*(.*)$/);
+        return match ? match[1].trim() : null;
+      })
+      .filter(Boolean);
+    res.json(questions);
+  } catch (err) {
+    console.error('Failed to read unanswered questions:', err);
+    res.status(500).json({ error: 'Failed to read unanswered questions' });
+  }
+});
+
+// Submit an answer for a question
+app.post('/api/answer', async (req, res) => {
+  const { question, answer } = req.body || {};
+  if (!question || !answer) {
+    return res.status(400).json({ error: 'question and answer required' });
+  }
+
+  try {
+    const faqFile = path.resolve(__dirname, 'ai_input/faq.txt');
+    const unansweredFile = path.resolve(__dirname, 'ai_fragen/offene_fragen.txt');
+
+    // Append to FAQ file
+    await fs.promises.appendFile(
+      faqFile,
+      `F:${question}\nA:${answer}\n`,
+      'utf8'
+    );
+
+    // Remove the question from offene_fragen.txt
+    const content = await fs.promises.readFile(unansweredFile, 'utf8');
+    const updated = content
+      .split(/\n+/)
+      .filter(line => !line.includes(`Frage: ${question}`))
+      .join('\n');
+    await fs.promises.writeFile(unansweredFile, updated + (updated.endsWith('\n') ? '' : '\n'), 'utf8');
+
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Failed to store answer:', err);
+    res.status(500).json({ error: 'Failed to store answer' });
+  }
+});
 
 // Basic health check
 //app.get("/", (req, res) => {
@@ -62,7 +146,7 @@ app.use((req, res) => {
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);
   // Save PID to file
-  fs.writeFileSync('server.pid', pid.toString(), (err) => {
+  fs.writeFile('server.pid', pid.toString(), err => {
     if (err) console.error('Error writing PID to server.pid:', err);
   });
 });

--- a/utils/summarizer.js
+++ b/utils/summarizer.js
@@ -23,7 +23,8 @@ async function summarizeConversation(messages) {
     const summaryMessage = {
       text: `Summary: ${summary}`,
       isUser: false,
-      timestamp: new Date()
+      // Use ISO string to match the timestamp format of other messages
+      timestamp: new Date().toISOString()
     };
     // Keep last 2 messages to maintain recent context
     return [summaryMessage, ...messages.slice(-2)];


### PR DESCRIPTION
## Summary
- export the `Conversation` model
- add `/api/threads` and `/api/threads/:id` endpoints
- fetch API via relative paths on the frontend
- clean up server route spacing

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857f2958d70832bbfdf2b50870501a4