### PR TITLE
Implement thread listing API and switch to relative URLs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -146,7 +146,7 @@
     // Load conversation threads
     async function loadThreads() {
       try {
-        const res = await fetch('https://dev.olomek.com/api/threads');
+        const res = await fetch('/api/threads');
         const threads = await res.json();
         threadsEl.innerHTML = '<h2>Unterhaltungen</h2>';
         threads.forEach(thread => {
@@ -169,7 +169,7 @@
       document.querySelectorAll('.thread').forEach(t => t.classList.remove('active'));
       document.querySelector(`.thread[data-conversation-id="${id}"]`).classList.add('active');
       try {
-        const res = await fetch(`https://dev.olomek.com/api/threads/${id}`);
+        const res = await fetch(`/api/threads/${id}`);
         const conversation = await res.json();
         conversation.messages.forEach(msg => {
           addMsg(msg.text, msg.isUser, msg.timestamp, !msg.isUser);
@@ -205,7 +205,7 @@
       sendBtnEl.disabled = true;
       typingEl.style.display = 'flex';
       try {
-        const res = await fetch('https://dev.olomek.com/api/chat', {
+        const res = await fetch('/api/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ prompt: txt, conversationId })

--- a/server.cjs
+++ b/server.cjs
@@ -11,10 +11,25 @@ const dotenv = require("dotenv");
 const bodyParser = require("body-parser");
 const { generateResponse } = require("./controllers/geminiController.cjs");
 const path = require('path');
+const { Sequelize } = require('sequelize');
+const ConversationModel = require('./models/Conversation');
 
 const pid = process.pid;
 
 dotenv.config();
+
+// Setup database connection for conversation threads
+const sequelize = new Sequelize({
+  dialect: 'sqlite',
+  storage: './chatbot.db',
+  logging: false
+});
+
+const Conversation = ConversationModel(sequelize);
+
+// Ensure database tables exist
+sequelize.sync({ alter: true })
+  .catch(err => console.error('SQLite sync error:', err.message));
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -43,6 +58,40 @@ app.use((req, res, next) => {
 
 // Routes
 app.post("/api/chat", generateResponse);
+
+// List conversation threads
+app.get('/api/threads', async (req, res) => {
+  try {
+    const convos = await Conversation.findAll({
+      order: [['updatedAt', 'DESC']]
+    });
+    const threads = convos.map(c => ({
+      conversationId: c.conversationId,
+      title: (c.messages && c.messages.length)
+        ? c.messages.find(m => m.isUser)?.text?.slice(0, 50) || ''
+        : ''
+    }));
+    res.json(threads);
+  } catch (err) {
+    console.error('Failed to load threads:', err);
+    res.status(500).json({ error: 'Failed to load threads' });
+  }
+});
+
+// Get a specific conversation by ID
+app.get('/api/threads/:id', async (req, res) => {
+  try {
+    const convo = await Conversation.findOne({ where: { conversationId: req.params.id } });
+    if (!convo) return res.status(404).json({ error: 'Not found' });
+    res.json({
+      conversationId: convo.conversationId,
+      messages: convo.messages
+    });
+  } catch (err) {
+    console.error('Failed to load conversation:', err);
+    res.status(500).json({ error: 'Failed to load conversation' });
+  }
+});
 
 // Return list of unanswered questions
 app.get('/api/unanswered', async (req, res) => {


### PR DESCRIPTION
## Summary
- add SQLite setup in server
- implement `/api/threads` and `/api/threads/:id` routes
- use relative URLs in the frontend for all API requests

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68583a0f8fcc832baf1adeafad7d52df