### PR TITLE
Password-protect Admin UI

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+API_KEY=your-google-api-key
+PORT=3000
+ADMIN_PASSWORD=tommy123

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project provides a simple Node.js server that exposes an API endpoint for a
    ```env
    API_KEY=your-google-api-key
    PORT=3000 # optional, defaults to 3000
+   ADMIN_PASSWORD=tommy123
    ```
 
 ## Running `server.cjs`
@@ -46,4 +47,6 @@ The log entry includes a timestamp and the original prompt.
 Zur Auflistung aller noch offenen Fragen kann `GET /api/unanswered` verwendet werden. Eine Antwort 
 kann – zusammen mit der ursprünglichen Frage – 
 mittels `POST /api/answer` im JSON-Body übermittelt werden. Eine einfache Administrationsoberfläche
-befindet sich unter `public/admin.html`.
+befindet sich unter `public/Admin/index.html` und ist per HTTP-Basic-Auth durch das in
+`ADMIN_PASSWORD` gesetzte Passwort geschützte Verzeichnis zugänglich. Standardmäßig ist das Passwort `tommy123`.
+Die vorherige Datei `public/admin.html` bleibt als Weiterleitung erhalten und führt automatisch auf das neue Verzeichnis.

--- a/public/Admin/index.html
+++ b/public/Admin/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Fragenverwaltung</title>
+  <script defer src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-6 font-sans">
+  <h1 class="text-2xl font-bold mb-4">Fragenverwaltung</h1>
+  <div class="mb-6 space-x-2">
+    <button id="tab-open" class="px-4 py-2 bg-blue-600 text-white rounded">Offene Fragen</button>
+    <button id="tab-answered" class="px-4 py-2 bg-gray-200 rounded">Bereits beantwortete Fragen</button>
+  </div>
+  <div id="open-list" class="space-y-4"></div>
+  <div id="answered-list" class="space-y-4 hidden"></div>
+
+  <script>
+  const openTab = document.getElementById('tab-open');
+  const answeredTab = document.getElementById('tab-answered');
+  const openList = document.getElementById('open-list');
+  const answeredList = document.getElementById('answered-list');
+
+  function showOpen() {
+    openList.classList.remove('hidden');
+    answeredList.classList.add('hidden');
+    openTab.classList.add('bg-blue-600','text-white');
+    answeredTab.classList.remove('bg-blue-600','text-white');
+    answeredTab.classList.add('bg-gray-200');
+    openTab.classList.remove('bg-gray-200');
+  }
+
+  function showAnswered() {
+    answeredList.classList.remove('hidden');
+    openList.classList.add('hidden');
+    answeredTab.classList.add('bg-blue-600','text-white');
+    openTab.classList.remove('bg-blue-600','text-white');
+    openTab.classList.add('bg-gray-200');
+    answeredTab.classList.remove('bg-gray-200');
+  }
+
+  openTab.addEventListener('click', showOpen);
+  answeredTab.addEventListener('click', showAnswered);
+
+  async function loadOpen() {
+    openList.innerHTML = '';
+    try {
+      const res = await fetch('/api/unanswered');
+      const questions = await res.json();
+      if (!Array.isArray(questions)) return;
+      questions.forEach(q => {
+        const div = document.createElement('div');
+        div.className = 'border p-4 rounded';
+        const form = document.createElement('form');
+        form.innerHTML = `
+          <p class="mb-2 font-medium">${q}</p>
+          <input type="hidden" name="question" value="${q}">
+          <input name="answer" class="border p-2 w-full mb-2" placeholder="Antwort" required>
+          <button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Senden</button>
+        `;
+        form.addEventListener('submit', async e => {
+          e.preventDefault();
+          const data = { question: q, answer: form.answer.value };
+          const resp = await fetch('/api/answer', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
+          });
+          if (resp.ok) div.remove();
+        });
+        div.appendChild(form);
+        openList.appendChild(div);
+      });
+    } catch (err) {
+      openList.innerHTML = '<div>Fehler beim Laden</div>';
+      console.error(err);
+    }
+  }
+
+  async function loadAnswered() {
+    answeredList.innerHTML = '';
+    try {
+      const res = await fetch('/api/answered');
+      const pairs = await res.json();
+      if (!Array.isArray(pairs)) return;
+      pairs.forEach(p => {
+        const div = document.createElement('div');
+        div.className = 'border p-4 rounded';
+        const form = document.createElement('form');
+        form.innerHTML = `
+          <p class="mb-2 font-medium">${p.question}</p>
+          <input type="hidden" name="question" value="${p.question}">
+          <input name="answer" class="border p-2 w-full mb-2" value="${p.answer}" required>
+          <button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Aktualisieren</button>
+        `;
+        form.addEventListener('submit', async e => {
+          e.preventDefault();
+          const data = { question: p.question, answer: form.answer.value };
+          await fetch('/api/update', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
+          });
+        });
+        div.appendChild(form);
+        answeredList.appendChild(div);
+      });
+    } catch (err) {
+      answeredList.innerHTML = '<div>Fehler beim Laden</div>';
+      console.error(err);
+    }
+  }
+
+  loadOpen();
+  loadAnswered();
+  </script>
+</body>
+</html>

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,55 +1,11 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>Unbeantwortete Fragen</title>
-  <script defer src="https://cdn.tailwindcss.com"></script>
+  <meta http-equiv="refresh" content="0; url=/Admin/">
+  <title>Redirecting...</title>
 </head>
-<body class="p-6 font-sans">
-  <h1 class="text-2xl font-bold mb-4">Unbeantwortete Fragen</h1>
-  <ul id="questions" class="space-y-4"></ul>
-
-  <script>
-  async function load() {
-    const list = document.getElementById('questions');
-    list.innerHTML = '';
-    try {
-      const res = await fetch('/api/unanswered');
-      const questions = await res.json();
-      if (!Array.isArray(questions)) return;
-      questions.forEach(q => {
-        const li = document.createElement('li');
-        li.className = 'border p-4 rounded';
-        const form = document.createElement('form');
-        form.innerHTML = `
-          <p class="mb-2 font-medium">${q}</p>
-          <input type="hidden" name="question" value="${q}">
-          <input name="answer" class="border p-2 w-full mb-2" placeholder="Antwort" required>
-          <button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Senden</button>
-        `;
-        form.addEventListener('submit', async e => {
-          e.preventDefault();
-          const data = {
-            question: q,
-            answer: form.answer.value
-          };
-          const resp = await fetch('/api/answer', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify(data)
-          });
-          if (resp.ok) li.remove();
-        });
-        li.appendChild(form);
-        list.appendChild(li);
-      });
-    } catch (err) {
-      list.innerHTML = '<li>Fehler beim Laden</li>';
-      console.error(err);
-    }
-  }
-  load();
-  </script>
+<body>
+  <p>Redirecting to <a href="/Admin/">/Admin/</a>...</p>
 </body>
 </html>

--- a/server.cjs
+++ b/server.cjs
@@ -146,12 +146,88 @@ app.post('/api/answer', async (req, res) => {
   }
 });
 
+// Return list of already answered questions
+app.get('/api/answered', async (req, res) => {
+  try {
+    const faqFile = path.resolve(__dirname, 'ai_input/faq.txt');
+    const data = await fs.promises.readFile(faqFile, 'utf8');
+    const lines = data.split(/\n+/).filter(Boolean);
+    const result = [];
+    for (let i = 0; i < lines.length; i++) {
+      const qMatch = lines[i].match(/^F:(.*)/);
+      const aMatch = lines[i + 1] && lines[i + 1].match(/^A:(.*)/);
+      if (qMatch && aMatch) {
+        result.push({
+          question: qMatch[1].trim(),
+          answer: aMatch[1].trim()
+        });
+        i++;
+      }
+    }
+    res.json(result);
+  } catch (err) {
+    console.error('Failed to read answered questions:', err);
+    res.status(500).json({ error: 'Failed to read answered questions' });
+  }
+});
+
+// Update an existing answer
+app.post('/api/update', async (req, res) => {
+  const { question, answer } = req.body || {};
+  if (!question || !answer) {
+    return res.status(400).json({ error: 'question and answer required' });
+  }
+  try {
+    const faqFile = path.resolve(__dirname, 'ai_input/faq.txt');
+    const lines = (await fs.promises.readFile(faqFile, 'utf8')).split(/\n/);
+    let found = false;
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].startsWith('F:') && lines[i].slice(2).trim() === question) {
+        if (i + 1 < lines.length && lines[i + 1].startsWith('A:')) {
+          lines[i + 1] = `A:${answer}`;
+          found = true;
+          break;
+        }
+      }
+    }
+    if (!found) {
+      return res.status(404).json({ error: 'Question not found' });
+    }
+    await fs.promises.writeFile(faqFile, lines.join('\n'), 'utf8');
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Failed to update answer:', err);
+    res.status(500).json({ error: 'Failed to update answer' });
+  }
+});
+
 // Basic health check
 //app.get("/", (req, res) => {
 //  res.send("Gemini Assistant API is running");
 //});
 
 // Serve static files from the public folder
+const adminPath = path.join(__dirname, 'public', 'Admin');
+const adminStatic = express.static(adminPath);
+
+function requireAdminAuth(req, res, next) {
+  const expected = process.env.ADMIN_PASSWORD || 'tommy123';
+  const auth = req.headers.authorization || '';
+  const [scheme, encoded] = auth.split(' ');
+  if (scheme !== 'Basic' || !encoded) {
+    res.set('WWW-Authenticate', 'Basic realm="Admin"');
+    return res.status(401).send('Authentication required');
+  }
+  const [, password] = Buffer.from(encoded, 'base64').toString().split(':');
+  if (!expected || password !== expected) {
+    res.set('WWW-Authenticate', 'Basic realm="Admin"');
+    return res.status(401).send('Authentication failed');
+  }
+  return adminStatic(req, res, next);
+}
+
+app.use('/Admin', requireAdminAuth);
+
 app.use(express.static(path.join(__dirname, 'public')));
 
 // Catch-all for debugging


### PR DESCRIPTION
## Summary
- default `ADMIN_PASSWORD` to `tommy123`
- document new password in README
- add sample `.env` file
- add HTTP auth for `/Admin` route
- restore admin interface with answered question editing
- add redirect from old `public/admin.html` to new `/Admin`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68584c939008832bac370ffa872ad9ed