### PR TITLE
Add placeholder handling for admin editor

### DIFF
--- a/public/admin2/admin.js
+++ b/public/admin2/admin.js
@@ -126,12 +126,41 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // initially show editor
   showEditor();
-=======
+
   const listEl = document.getElementById('headline-list');
   const searchEl = document.getElementById('search');
   const editorEl = document.getElementById('editor');
   const addBtn = document.getElementById('add-heading');
   const pane = document.getElementById('editor-pane');
+
+  const placeholderText = editorEl.dataset.placeholder || '';
+
+  function showPlaceholder() {
+    if (!editorEl.textContent.trim()) {
+      editorEl.textContent = placeholderText;
+      editorEl.classList.add('text-gray-400');
+      editorEl.dataset.showingPlaceholder = 'true';
+    }
+  }
+
+  function hidePlaceholder() {
+    if (editorEl.dataset.showingPlaceholder === 'true') {
+      editorEl.textContent = '';
+      editorEl.classList.remove('text-gray-400');
+      delete editorEl.dataset.showingPlaceholder;
+    }
+  }
+
+  editorEl.addEventListener('focus', hidePlaceholder);
+  editorEl.addEventListener('blur', showPlaceholder);
+  editorEl.addEventListener('input', () => {
+    if (editorEl.textContent.trim()) {
+      editorEl.classList.remove('text-gray-400');
+      delete editorEl.dataset.showingPlaceholder;
+    }
+  });
+
+  showPlaceholder();
 
   // create headline input
   const headlineInput = document.createElement('input');
@@ -202,6 +231,11 @@ document.addEventListener('DOMContentLoaded', () => {
       currentId = entry.id;
       headlineInput.value = entry.headline;
       editorEl.innerHTML = entry.text;
+      if (entry.text) {
+        hidePlaceholder();
+      } else {
+        showPlaceholder();
+      }
       activeCheckbox.checked = !!entry.active;
     } catch (err) {
       console.error('Failed to load entry', err);
@@ -248,6 +282,7 @@ document.addEventListener('DOMContentLoaded', () => {
         currentId = null;
         headlineInput.value = '';
         editorEl.innerHTML = '';
+        showPlaceholder();
         activeCheckbox.checked = false;
         await loadHeadlines();
       }
@@ -262,6 +297,7 @@ document.addEventListener('DOMContentLoaded', () => {
     currentId = null;
     headlineInput.value = '';
     editorEl.innerHTML = '';
+    showPlaceholder();
     activeCheckbox.checked = true;
   });
 

--- a/public/admin2/index.html
+++ b/public/admin2/index.html
@@ -59,10 +59,8 @@
         id="editor"
         class="flex-1 p-4 bg-white overflow-y-auto"
         contenteditable="true"
-        placeholder="Enter text here..."
+        data-placeholder="Click here to edit the text content..."
       >
-        <!-- Placeholder content -->
-        <p>Click here to edit the text content...</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- move editor placeholder text to `data-placeholder` in admin UI
- implement JS logic to show/hide placeholder on focus, blur, and typing
- ensure placeholder appears when clearing or loading empty entries

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685fd9db7e3c832b9c8443be59ba2474