### PR TITLE
Add basic login prompt and auth header handling

### DIFF
--- a/public/admin2/admin.js
+++ b/public/admin2/admin.js
@@ -1,4 +1,35 @@
 document.addEventListener('DOMContentLoaded', () => {
+  function ensureLoggedIn() {
+    let token = sessionStorage.getItem('adminToken');
+    while (token !== 'htw123') {
+      const pwd = prompt('Admin Passwort eingeben:');
+      if (pwd === null) {
+        alert('Login erforderlich');
+      } else if (pwd === 'htw123') {
+        token = pwd;
+        sessionStorage.setItem('adminToken', token);
+      }
+      if (token) break;
+    }
+  }
+
+  ensureLoggedIn();
+
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = async (input, init = {}) => {
+    init.headers = init.headers || {};
+    const token = sessionStorage.getItem('adminToken');
+    if (token) {
+      init.headers['Authorization'] = `Bearer ${token}`;
+    }
+    const res = await originalFetch(input, init);
+    if (res.status === 401) {
+      sessionStorage.removeItem('adminToken');
+      alert('Session abgelaufen, bitte erneut anmelden');
+      location.reload();
+    }
+    return res;
+  };
   // Tabs for switching between editor and question management
   const editorBtn = document.getElementById('btn-editor');
   const questionsBtn = document.getElementById('btn-questions');


### PR DESCRIPTION
## Summary
- prompt for admin password on load in admin2 interface
- store token in sessionStorage and inject Authorization header for all fetch calls
- clear token and reload on 401 responses

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fd9dd649c832bb5df7ba97e4e52a5