### PR TITLE
Add admin auth token constant and headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ This project provides a simple Node.js server that exposes an API endpoint for a
    ```env
    API_KEY=your-google-api-key
    PORT=3000 # optional, defaults to 3000
-   ADMIN_TOKEN=choose-a-secret-token
+   ADMIN_TOKEN=htw123
    ```
 
    Requests to admin endpoints (e.g. `/api/admin/*`, `/api/answer`, `/api/update`)
    must include this token in the `Authorization` header as `Bearer <token>`.
+
+   The admin interface in `public/admin2/` uses the token `htw123` by default.
+   Make sure the `ADMIN_TOKEN` in your `.env` matches this value or adjust the
+   `AUTH_TOKEN` constant in `public/admin2/admin.js` accordingly.
 
 ## Running `server.cjs`
 

--- a/public/admin2/admin.js
+++ b/public/admin2/admin.js
@@ -1,3 +1,5 @@
+const AUTH_TOKEN = 'htw123';
+
 document.addEventListener('DOMContentLoaded', () => {
   // Tabs for switching between editor and question management
   const editorBtn = document.getElementById('btn-editor');
@@ -58,7 +60,12 @@ document.addEventListener('DOMContentLoaded', () => {
   async function loadOpen() {
     openList.innerHTML = '';
     try {
-      const res = await fetch('/api/unanswered');
+      const res = await fetch('/api/unanswered', {
+        headers: {
+          Authorization: `Bearer ${AUTH_TOKEN}`,
+          'Content-Type': 'application/json'
+        }
+      });
       const questions = await res.json();
       if (!Array.isArray(questions)) return;
       questions.forEach(q => {
@@ -76,7 +83,10 @@ document.addEventListener('DOMContentLoaded', () => {
           const data = { question: q, answer: form.answer.value };
           const resp = await fetch('/api/answer', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+              Authorization: `Bearer ${AUTH_TOKEN}`,
+              'Content-Type': 'application/json'
+            },
             body: JSON.stringify(data)
           });
           if (resp.ok) div.remove();
@@ -93,7 +103,12 @@ document.addEventListener('DOMContentLoaded', () => {
   async function loadAnswered() {
     answeredList.innerHTML = '';
     try {
-      const res = await fetch('/api/answered');
+      const res = await fetch('/api/answered', {
+        headers: {
+          Authorization: `Bearer ${AUTH_TOKEN}`,
+          'Content-Type': 'application/json'
+        }
+      });
       const pairs = await res.json();
       if (!Array.isArray(pairs)) return;
       pairs.forEach(p => {
@@ -111,7 +126,10 @@ document.addEventListener('DOMContentLoaded', () => {
           const data = { question: p.question, answer: form.answer.value };
           await fetch('/api/update', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+              Authorization: `Bearer ${AUTH_TOKEN}`,
+              'Content-Type': 'application/json'
+            },
             body: JSON.stringify(data)
           });
         });
@@ -126,7 +144,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // initially show editor
   showEditor();
-=======
   const listEl = document.getElementById('headline-list');
   const searchEl = document.getElementById('search');
   const editorEl = document.getElementById('editor');
@@ -174,7 +191,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function loadHeadlines() {
     try {
-      const res = await fetch('/api/admin/headlines');
+      const res = await fetch('/api/admin/headlines', {
+        headers: {
+          Authorization: `Bearer ${AUTH_TOKEN}`,
+          'Content-Type': 'application/json'
+        }
+      });
       allHeadlines = await res.json();
       renderHeadlines(allHeadlines);
     } catch (err) {
@@ -196,7 +218,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function loadEntry(id) {
     try {
-      const res = await fetch(`/api/admin/entries/${id}`);
+      const res = await fetch(`/api/admin/entries/${id}`, {
+        headers: {
+          Authorization: `Bearer ${AUTH_TOKEN}`,
+          'Content-Type': 'application/json'
+        }
+      });
       if (!res.ok) return;
       const entry = await res.json();
       currentId = entry.id;
@@ -220,13 +247,19 @@ document.addEventListener('DOMContentLoaded', () => {
       if (currentId) {
         res = await fetch(`/api/admin/entries/${currentId}`, {
           method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            Authorization: `Bearer ${AUTH_TOKEN}`,
+            'Content-Type': 'application/json'
+          },
           body: JSON.stringify(payload)
         });
       } else {
         res = await fetch('/api/admin/entries', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            Authorization: `Bearer ${AUTH_TOKEN}`,
+            'Content-Type': 'application/json'
+          },
           body: JSON.stringify(payload)
         });
       }
@@ -243,7 +276,13 @@ document.addEventListener('DOMContentLoaded', () => {
   async function deleteEntry() {
     if (!currentId) return;
     try {
-      const res = await fetch(`/api/admin/entries/${currentId}`, { method: 'DELETE' });
+      const res = await fetch(`/api/admin/entries/${currentId}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${AUTH_TOKEN}`,
+          'Content-Type': 'application/json'
+        }
+      });
       if (res.ok) {
         currentId = null;
         headlineInput.value = '';


### PR DESCRIPTION
## Summary
- set `AUTH_TOKEN` constant in `public/admin2/admin.js`
- attach Authorization header to admin fetch requests
- document required `ADMIN_TOKEN` value for the admin interface

## Testing
- `node -c public/admin2/admin.js`

------
https://chatgpt.com/codex/tasks/task_e_685fd9dab080832b9fcd511c0b1d0ab6