### PR TITLE
Add editor tracking and archive restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ visit `/admin2/` on the running server to use it.
 
 The page communicates with several JSON endpoints:
 
-* `GET /api/admin/headlines` – list headlines of all **active** entries.
+* `GET /api/admin/headlines` – list headlines of all **active** entries. The response
+  also includes the text of each entry so the admin interface can search
+  through both headline and content.
 * `GET /api/admin/entries/:id` – retrieve a single entry by id.
 * `POST /api/admin/entries` – create a new entry. Provide `headline` and `text`
   in the request body.
@@ -75,9 +77,16 @@ The page communicates with several JSON endpoints:
   created and returned.
 * `DELETE /api/admin/entries/:id` – archive an entry by setting `active` to
   `false` and recording the time in `archived`.
+* `GET /api/admin/archive` – return all archived entries ordered by the time they
+  were archived.
+* `POST /api/admin/restore/:id` – restore an archived entry. The current active
+  version (if any) is archived and a new entry is created from the archived data.
 
 Only active records are served by the API. Archived entries remain in the
 database for reference and history tracking.
+
+Each entry also stores the name of the editor in the `editor` field which is
+archived together with older versions.
 
 If the unanswered‑question workflow from `public/admin.html` is added to this
 interface, you can review questions logged in

--- a/public/admin2/admin.js
+++ b/public/admin2/admin.js
@@ -35,31 +35,58 @@ document.addEventListener('DOMContentLoaded', () => {
   // Tabs for switching between editor and question management
   const editorBtn = document.getElementById('btn-editor');
   const questionsBtn = document.getElementById('btn-questions');
+  const archiveBtn = document.getElementById('btn-archive');
+  const openCountSpan = document.getElementById('open-count');
   const editorView = document.getElementById('editor-view');
   const questionsView = document.getElementById('questions-view');
+  const archiveView = document.getElementById('archive-view');
 
   function showEditor() {
     editorView.classList.remove('hidden');
     questionsView.classList.add('hidden');
+    archiveView.classList.add('hidden');
     editorBtn.classList.add('bg-blue-600', 'text-white');
     editorBtn.classList.remove('bg-gray-200');
     questionsBtn.classList.remove('bg-blue-600', 'text-white');
     questionsBtn.classList.add('bg-gray-200');
+    archiveBtn.classList.remove('bg-blue-600', 'text-white');
+    archiveBtn.classList.add('bg-gray-200');
   }
 
   function showQuestions() {
     questionsView.classList.remove('hidden');
     editorView.classList.add('hidden');
+    archiveView.classList.add('hidden');
     questionsBtn.classList.add('bg-blue-600', 'text-white');
     questionsBtn.classList.remove('bg-gray-200');
     editorBtn.classList.remove('bg-blue-600', 'text-white');
     editorBtn.classList.add('bg-gray-200');
+    archiveBtn.classList.remove('bg-blue-600', 'text-white');
+    archiveBtn.classList.add('bg-gray-200');
     loadOpen();
     loadAnswered();
   }
 
+  function updateOpenCount(num) {
+    if (openCountSpan) openCountSpan.textContent = num;
+  }
+
+  function showArchive() {
+    archiveView.classList.remove('hidden');
+    editorView.classList.add('hidden');
+    questionsView.classList.add('hidden');
+    archiveBtn.classList.add('bg-blue-600', 'text-white');
+    archiveBtn.classList.remove('bg-gray-200');
+    editorBtn.classList.remove('bg-blue-600', 'text-white');
+    editorBtn.classList.add('bg-gray-200');
+    questionsBtn.classList.remove('bg-blue-600', 'text-white');
+    questionsBtn.classList.add('bg-gray-200');
+    loadArchive();
+  }
+
   editorBtn.addEventListener('click', showEditor);
   questionsBtn.addEventListener('click', showQuestions);
+  archiveBtn.addEventListener('click', showArchive);
 
   // Question management logic (copied from public/admin/index.html)
   const tabOpen = document.getElementById('tab-open');
@@ -99,6 +126,7 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       const questions = await res.json();
       if (!Array.isArray(questions)) return;
+      updateOpenCount(questions.length);
       questions.forEach(q => {
         const div = document.createElement('div');
         div.className = 'border p-4 rounded';
@@ -106,12 +134,13 @@ document.addEventListener('DOMContentLoaded', () => {
         form.innerHTML = `
           <p class="mb-2 font-medium">${q}</p>
           <input type="hidden" name="question" value="${q}">
+          <input name="editor" class="border p-2 w-full mb-2" placeholder="Name" required>
           <input name="answer" class="border p-2 w-full mb-2" placeholder="Antwort" required>
           <button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Senden</button>
         `;
         form.addEventListener('submit', async e => {
           e.preventDefault();
-          const data = { question: q, answer: form.answer.value };
+          const data = { question: q, answer: form.answer.value, editor: form.editor.value };
           const resp = await fetch('/api/answer', {
             method: 'POST',
             headers: {
@@ -120,7 +149,10 @@ document.addEventListener('DOMContentLoaded', () => {
             },
             body: JSON.stringify(data)
           });
-          if (resp.ok) div.remove();
+          if (resp.ok) {
+            div.remove();
+            updateOpenCount(Math.max(0, parseInt(openCountSpan.textContent) - 1));
+          }
         });
         div.appendChild(form);
         openList.appendChild(div);
@@ -149,12 +181,13 @@ document.addEventListener('DOMContentLoaded', () => {
         form.innerHTML = `
           <p class="mb-2 font-medium">${p.question}</p>
           <input type="hidden" name="question" value="${p.question}">
+          <input name="editor" class="border p-2 w-full mb-2" placeholder="Name" required>
           <input name="answer" class="border p-2 w-full mb-2" value="${p.answer}" required>
           <button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Aktualisieren</button>
         `;
         form.addEventListener('submit', async e => {
           e.preventDefault();
-          const data = { question: p.question, answer: form.answer.value };
+          const data = { question: p.question, answer: form.answer.value, editor: form.editor.value };
           await fetch('/api/update', {
             method: 'POST',
             headers: {
@@ -175,13 +208,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // initially show editor
   showEditor();
-
-=======
-
-=======
+  loadOpen();
 
 
-=======
+
+
 
 
   const listEl = document.getElementById('headline-list');
@@ -189,6 +220,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const editorEl = document.getElementById('editor');
   const addBtn = document.getElementById('add-heading');
   const pane = document.getElementById('editor-pane');
+  const archiveList = document.getElementById('archive-list');
+  const archiveSearch = document.getElementById('archive-search');
+  const archiveSort = document.getElementById('archive-sort');
 
 
   const placeholderText = editorEl.dataset.placeholder || '';
@@ -219,11 +253,9 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   showPlaceholder();
-=======
   const boldBtn = document.getElementById('btn-bold');
   const italicBtn = document.getElementById('btn-italic');
   const linkBtn = document.getElementById('btn-link');
-  const headingBtn = document.getElementById('btn-heading');
 
   function exec(command, arg = null) {
     document.execCommand(command, false, arg);
@@ -236,7 +268,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const url = prompt('Enter link URL');
     if (url) exec('createLink', url);
   });
-  headingBtn.addEventListener('click', () => exec('formatBlock', 'h2'));
 
 
   // create headline input
@@ -245,6 +276,12 @@ document.addEventListener('DOMContentLoaded', () => {
   headlineInput.placeholder = 'Headline';
   headlineInput.className = 'p-2 border border-gray-300 rounded mb-2';
   pane.insertBefore(headlineInput, pane.firstChild);
+
+  const editorNameInput = document.createElement('input');
+  editorNameInput.id = 'editor-name';
+  editorNameInput.placeholder = 'Name';
+  editorNameInput.className = 'p-2 border border-gray-300 rounded mb-2';
+  pane.insertBefore(editorNameInput, pane.firstChild);
 
   // footer controls
   const controls = document.createElement('div');
@@ -277,6 +314,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   let currentId = null;
   let allHeadlines = [];
+  let archiveEntries = [];
 
   async function loadHeadlines() {
     try {
@@ -317,6 +355,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const entry = await res.json();
       currentId = entry.id;
       headlineInput.value = entry.headline;
+      editorNameInput.value = entry.editor || '';
       editorEl.innerHTML = entry.text;
       if (entry.text) {
         hidePlaceholder();
@@ -333,7 +372,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const payload = {
       headline: headlineInput.value.trim(),
       text: editorEl.innerHTML.trim(),
-      active: activeCheckbox.checked
+      active: activeCheckbox.checked,
+      editor: editorNameInput.value.trim()
     };
     if (!payload.headline || !payload.text) return;
     try {
@@ -380,6 +420,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (res.ok) {
         currentId = null;
         headlineInput.value = '';
+        editorNameInput.value = '';
         editorEl.innerHTML = '';
         showPlaceholder();
         activeCheckbox.checked = false;
@@ -395,16 +436,88 @@ document.addEventListener('DOMContentLoaded', () => {
   addBtn.addEventListener('click', () => {
     currentId = null;
     headlineInput.value = '';
+    editorNameInput.value = '';
     editorEl.innerHTML = '';
     showPlaceholder();
     activeCheckbox.checked = true;
   });
 
+  async function loadArchive() {
+    try {
+      const res = await fetch('/api/admin/archive', {
+        headers: {
+          Authorization: `Bearer ${AUTH_TOKEN}`,
+          'Content-Type': 'application/json'
+        }
+      });
+      archiveEntries = await res.json();
+      if (!Array.isArray(archiveEntries)) archiveEntries = [];
+      renderArchive();
+    } catch (err) {
+      archiveList.innerHTML = '<div>Fehler beim Laden</div>';
+      console.error('Failed to load archive', err);
+    }
+  }
+
+  function renderArchive() {
+    let items = archiveEntries.slice();
+    const q = archiveSearch.value.toLowerCase();
+    if (q) {
+      items = items.filter(e =>
+        e.headline.toLowerCase().includes(q) ||
+        (e.text && e.text.toLowerCase().includes(q)) ||
+        (e.editor && e.editor.toLowerCase().includes(q))
+      );
+    }
+    const sort = archiveSort.value;
+    if (sort === 'oldest') {
+      items.sort((a,b) => new Date(a.archived) - new Date(b.archived));
+    } else if (sort === 'editor') {
+      items.sort((a,b) => (a.editor||'').localeCompare(b.editor||''));
+    } else {
+      items.sort((a,b) => new Date(b.archived) - new Date(a.archived));
+    }
+    archiveList.innerHTML = '';
+    items.forEach(e => {
+      const div = document.createElement('div');
+      div.className = 'border p-4 rounded';
+      const date = e.archived ? new Date(e.archived).toLocaleString() : '';
+      div.innerHTML = `<h3 class="font-semibold mb-1">${e.headline}</h3>
+        <p class="text-sm text-gray-500 mb-2">${date} - ${e.editor || ''}</p>
+        <div class="text-sm mb-2">${e.text}</div>`;
+      const btn = document.createElement('button');
+      btn.className = 'px-2 py-1 bg-blue-500 text-white rounded';
+      btn.textContent = 'Wiederherstellen';
+      btn.addEventListener('click', async () => {
+        const name = prompt('Name des Editors?');
+        if (name === null) return;
+        await fetch(`/api/admin/restore/${e.id}`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${AUTH_TOKEN}`,
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ editor: name })
+        });
+        await loadHeadlines();
+        alert('Wiederhergestellt');
+      });
+      div.appendChild(btn);
+      archiveList.appendChild(div);
+    });
+  }
+
   searchEl.addEventListener('input', () => {
     const q = searchEl.value.toLowerCase();
-    const filtered = allHeadlines.filter(h => h.headline.toLowerCase().includes(q));
+    const filtered = allHeadlines.filter(h =>
+      h.headline.toLowerCase().includes(q) ||
+      (h.text && h.text.toLowerCase().includes(q))
+    );
     renderHeadlines(filtered);
   });
+
+  archiveSearch.addEventListener('input', renderArchive);
+  archiveSort.addEventListener('change', renderArchive);
 
   loadHeadlines();
 

--- a/public/admin2/index.html
+++ b/public/admin2/index.html
@@ -11,7 +11,10 @@
   <!-- Top navigation -->
   <div class="p-4 bg-white border-b flex space-x-2">
     <button id="btn-editor" class="px-4 py-2 bg-blue-600 text-white rounded">Editor</button>
-    <button id="btn-questions" class="px-4 py-2 bg-gray-200 rounded">Fragen</button>
+    <button id="btn-questions" class="px-4 py-2 bg-gray-200 rounded">Fragen
+      <span id="open-count" class="ml-1 text-sm bg-red-500 text-white rounded-full px-2">0</span>
+    </button>
+    <button id="btn-archive" class="px-4 py-2 bg-gray-200 rounded">Archiv</button>
   </div>
 
   <!-- Editor View -->
@@ -52,12 +55,11 @@
         <button id="btn-bold" class="px-3 py-1 border border-gray-300 rounded hover:bg-gray-100">B</button>
         <button id="btn-italic" class="px-3 py-1 border border-gray-300 rounded hover:bg-gray-100">I</button>
         <button id="btn-link" class="px-3 py-1 border border-gray-300 rounded hover:bg-gray-100">Link</button>
-        <button id="btn-heading" class="px-3 py-1 border border-gray-300 rounded hover:bg-gray-100">Heading</button>
       </div>
       <!-- Editable Text Area -->
       <div
         id="editor"
-        class="flex-1 p-4 bg-white overflow-y-auto"
+        class="p-4 bg-white overflow-y-auto h-96 flex-none"
         contenteditable="true"
         data-placeholder="Click here to edit the text content..."
       >
@@ -76,8 +78,20 @@
     <div id="answered-list" class="space-y-4 hidden"></div>
   </div>
 
+  <!-- Archive View -->
+  <div id="archive-view" class="flex flex-col flex-1 hidden p-4 space-y-4 overflow-y-auto">
+    <div class="flex mb-2">
+      <input id="archive-search" class="flex-1 p-2 border rounded mr-2" placeholder="Suche...">
+      <select id="archive-sort" class="p-2 border rounded">
+        <option value="newest">Neueste</option>
+        <option value="oldest">Älteste</option>
+        <option value="editor">Geändert von</option>
+      </select>
+    </div>
+    <div id="archive-list" class="space-y-4"></div>
+  </div>
+
   <script src="admin.js" defer></script>
-=======
   
 
 </body>

--- a/server.cjs
+++ b/server.cjs
@@ -19,7 +19,7 @@ const express = require("express");
 const dotenv = require("dotenv");
 const bodyParser = require("body-parser");
 const { generateResponse } = require("./controllers/geminiController.cjs");
-const { getHeadlines, getEntry, createEntry, updateEntry, deleteEntry } = require("./controllers/adminController.cjs");
+const { getHeadlines, getEntry, createEntry, updateEntry, deleteEntry, getArchive, restoreEntry } = require("./controllers/adminController.cjs");
 const path = require('path');
 const { Sequelize } = require('sequelize');
 const ConversationModel = require('./models/Conversation');
@@ -127,7 +127,7 @@ app.get('/api/unanswered', adminAuth, async (req, res) => {
 
 // Submit an answer for a question
 app.post('/api/answer', adminAuth, async (req, res) => {
-  const { question, answer } = req.body || {};
+  const { question, answer, editor } = req.body || {};
   if (!question || !answer) {
     return res.status(400).json({ error: 'question and answer required' });
   }
@@ -139,7 +139,7 @@ app.post('/api/answer', adminAuth, async (req, res) => {
     // Append to FAQ file
     await fs.promises.appendFile(
       faqFile,
-      `F:${question}\nA:${answer}\n`,
+      `F:${question}\nA:${answer}\nE:${editor || ''}\n`,
       'utf8'
     );
 
@@ -169,11 +169,13 @@ app.get('/api/answered', adminAuth, async (req, res) => {
       const qMatch = lines[i].match(/^F:(.*)/);
       const aMatch = lines[i + 1] && lines[i + 1].match(/^A:(.*)/);
       if (qMatch && aMatch) {
+        const eMatch = lines[i + 2] && lines[i + 2].match(/^E:(.*)/);
         result.push({
           question: qMatch[1].trim(),
-          answer: aMatch[1].trim()
+          answer: aMatch[1].trim(),
+          editor: eMatch ? eMatch[1].trim() : ''
         });
-        i++; // skip next line
+        i += eMatch ? 2 : 1;
       }
     }
     res.json(result);
@@ -185,7 +187,7 @@ app.get('/api/answered', adminAuth, async (req, res) => {
 
 // Update an existing answer
 app.post('/api/update', adminAuth, async (req, res) => {
-  const { question, answer } = req.body || {};
+  const { question, answer, editor } = req.body || {};
   if (!question || !answer) {
     return res.status(400).json({ error: 'question and answer required' });
   }
@@ -197,6 +199,11 @@ app.post('/api/update', adminAuth, async (req, res) => {
       if (lines[i].startsWith('F:') && lines[i].slice(2).trim() === question) {
         if (i + 1 < lines.length && lines[i + 1].startsWith('A:')) {
           lines[i + 1] = `A:${answer}`;
+          if (i + 2 < lines.length && lines[i + 2].startsWith('E:')) {
+            lines[i + 2] = `E:${editor || ''}`;
+          } else {
+            lines.splice(i + 2, 0, `E:${editor || ''}`);
+          }
           found = true;
           break;
         }
@@ -218,6 +225,8 @@ app.post('/api/update', adminAuth, async (req, res) => {
 // Admin routes Grok/thomas
 app.use('/api/admin', adminAuth);
 app.get("/api/admin/headlines", getHeadlines);
+app.get("/api/admin/archive", getArchive);
+app.post("/api/admin/restore/:id", restoreEntry);
 app.get("/api/admin/entries/:id", getEntry);
 app.post("/api/admin/entries", createEntry);
 app.put("/api/admin/entries/:id", updateEntry);


### PR DESCRIPTION
## Summary
- track editor name for entries
- support restoring archived entries and record editor
- show open question count and add archive search/sort
- store editor with FAQ answers

## Testing
- `node --check controllers/adminController.cjs`
- `node --check public/admin2/admin.js`
- `node --check server.cjs`
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685fdc065888832b899e90b7719fd8e1