### PR TITLE
Implement admin interface improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ nohup.out
 server.pid
 ai_fragen/offene_fragen.txt
 cron/cron.log
+logs/audit.log

--- a/README.md
+++ b/README.md
@@ -14,16 +14,13 @@ This project provides a simple Node.js server that exposes an API endpoint for a
    Create a `.env` file in the project root containing the API key for the Gemini API and an optional port:
    ```env
    API_KEY=your-google-api-key
-   PORT=3000 # optional, defaults to 3000
-   ADMIN_TOKEN=htw123
+  PORT=3000 # optional, defaults to 3000
    ```
 
-   Requests to admin endpoints (e.g. `/api/admin/*`, `/api/answer`, `/api/update`)
-   must include this token in the `Authorization` header as `Bearer <token>`.
-
-   The admin interface in `public/admin2/` uses the token `htw123` by default.
-   Make sure the `ADMIN_TOKEN` in your `.env` matches this value or adjust the
-   `AUTH_TOKEN` constant in `public/admin2/admin.js` accordingly.
+  The admin interface now requires login with a username and password.
+  A default user `admin` with password `admin` is created when the
+  database is initialized. After logging in, the browser stores a session
+  token which is sent with all admin requests.
 
 ## Running `server.cjs`
 

--- a/controllers/adminController.cjs
+++ b/controllers/adminController.cjs
@@ -1,12 +1,5 @@
 const { Sequelize, DataTypes } = require('sequelize');
-const path = require('path');
-
-// Initialize SQLite database
-const sequelize = new Sequelize({
-  dialect: 'sqlite',
-  storage: path.join(__dirname, '../hochschuhl-abc.db'),
-  logging: false
-});
+const sequelize = require('./db.cjs');
 
 // Define HochschuhlABC model
 const HochschuhlABC = sequelize.define('HochschuhlABC', {
@@ -192,3 +185,5 @@ exports.restoreEntry = async (req, res) => {
     res.status(500).json({ error: 'Failed to restore entry' });
   }
 };
+
+module.exports.HochschuhlABC = HochschuhlABC;

--- a/controllers/authController.cjs
+++ b/controllers/authController.cjs
@@ -1,0 +1,29 @@
+const { DataTypes } = require('sequelize');
+const crypto = require('crypto');
+const sequelize = require('./db.cjs');
+
+const AdminUser = sequelize.define('AdminUser', {
+  id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+  username: { type: DataTypes.STRING, unique: true },
+  passwordHash: { type: DataTypes.STRING }
+}, { tableName: 'admin_users', timestamps: false });
+
+async function init() {
+  await AdminUser.sync();
+  const count = await AdminUser.count();
+  if (count === 0) {
+    await AdminUser.create({ username: 'admin', passwordHash: hash('admin') });
+  }
+}
+
+function hash(password) {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+async function verifyUser(username, password) {
+  const user = await AdminUser.findOne({ where: { username } });
+  if (!user) return false;
+  return user.passwordHash === hash(password);
+}
+
+module.exports = { AdminUser, init, verifyUser, hash };

--- a/controllers/db.cjs
+++ b/controllers/db.cjs
@@ -1,0 +1,10 @@
+const { Sequelize } = require('sequelize');
+const path = require('path');
+
+const sequelize = new Sequelize({
+  dialect: 'sqlite',
+  storage: path.join(__dirname, '../hochschuhl-abc.db'),
+  logging: false
+});
+
+module.exports = sequelize;

--- a/public/admin2/index.html
+++ b/public/admin2/index.html
@@ -5,9 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Admin - Hochschuhl ABC Management</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+  <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
   <script defer src="admin.js"></script>
 </head>
 <body class="bg-gray-100 flex flex-col h-screen">
+  <div id="login-screen" class="absolute inset-0 flex items-center justify-center bg-gray-100">
+    <form id="login-form" class="bg-white p-4 rounded shadow space-y-2">
+      <input id="login-user" class="border p-2 w-64" placeholder="User">
+      <input id="login-pass" type="password" class="border p-2 w-64" placeholder="Password">
+      <button class="w-full bg-blue-600 text-white px-4 py-2 rounded" type="submit">Login</button>
+    </form>
+  </div>
   <!-- Top navigation -->
   <div class="p-4 bg-white border-b flex space-x-2">
     <button id="btn-editor" class="px-4 py-2 bg-blue-600 text-white rounded">Editor</button>
@@ -47,33 +56,21 @@
 
     <!-- Right Content Area: Text Editor (80%) -->
     <div id="editor-pane" class="w-4/5 flex flex-col">
-      <!-- Formatting Buttons -->
-      <div class="p-4 bg-white border-b border-gray-200 flex space-x-2">
-        <button id="btn-bold" class="px-3 py-1 border border-gray-300 rounded hover:bg-gray-100">B</button>
-        <button id="btn-italic" class="px-3 py-1 border border-gray-300 rounded hover:bg-gray-100">I</button>
-        <button id="btn-link" class="px-3 py-1 border border-gray-300 rounded hover:bg-gray-100">Link</button>
-      </div>
+      <div id="quill-toolbar" class="p-2 bg-white border-b border-gray-200"></div>
       <!-- Editor name and headline -->
       <div class="p-4 bg-white border-b border-gray-200 flex space-x-2">
         <input id="editor-name" class="p-2 border border-gray-300 rounded w-1/3" placeholder="Name">
         <input id="headline-input" class="p-2 border border-gray-300 rounded flex-1" placeholder="\u00dcberschrift">
       </div>
       <!-- Editable Text Area -->
-      <div
-        id="editor"
-
-        class="p-4 bg-white overflow-y-auto h-96 flex-none"
-
-        contenteditable="true"
-        data-placeholder="Click here to edit the text content..."
-      >
-      </div>
+      <div id="editor" class="h-96"></div>
     </div>
   </div>
 
 
   <!-- Question Management View -->
   <div id="questions-view" class="flex flex-col flex-1 hidden p-4 space-y-4 overflow-y-auto">
+    <input id="question-search" class="p-2 border rounded mb-2" placeholder="Suche...">
     <div class="mb-4 space-x-2">
       <button id="tab-open" class="px-4 py-2 bg-blue-600 text-white rounded">Offene Fragen</button>
       <button id="tab-answered" class="px-4 py-2 bg-gray-200 rounded">Bereits beantwortete Fragen</button>


### PR DESCRIPTION
## Summary
- add Sequelize DB helper and new auth controller with default user
- implement login/session system with audit logging
- include data export endpoint
- switch admin editor to Quill and add diff view for archive
- update README for new login workflow

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6860200d84fc832ba0fe7d76fe3c62e6