### PR TITLE
Add user roles and enhanced admin features

### DIFF
--- a/controllers/adminController.cjs
+++ b/controllers/adminController.cjs
@@ -44,9 +44,18 @@ sequelize.sync({ alter: true })
 // Get all active headlines (include text for searching)
 exports.getHeadlines = async (req, res) => {
   try {
+    const where = { active: true };
+    const { q } = req.query;
+    if (q) {
+      where[Sequelize.Op.or] = [
+        { headline: { [Sequelize.Op.like]: `%${q}%` } },
+        { text: { [Sequelize.Op.like]: `%${q}%` } },
+        { editor: { [Sequelize.Op.like]: `%${q}%` } }
+      ];
+    }
     const headlines = await HochschuhlABC.findAll({
       attributes: ['id', 'headline', 'text'],
-      where: { active: true },
+      where,
       order: [['lastUpdated', 'DESC']]
     });
     res.json(headlines);

--- a/public/admin2/admin.js
+++ b/public/admin2/admin.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if(res.ok){
       const data=await res.json();
       sessionStorage.setItem('sessionToken',data.token);
+      sessionStorage.setItem('userRole', data.role);
       loginScreen.classList.add('hidden');
       init();
     }else{alert('Login fehlgeschlagen');}
@@ -17,7 +18,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   loginForm.addEventListener('submit',e=>{e.preventDefault();doLogin(userInput.value,passInput.value);});
 
-  if(sessionStorage.getItem('sessionToken')){loginScreen.classList.add('hidden');init();}
+  if(sessionStorage.getItem('sessionToken')){
+    loginScreen.classList.add('hidden');
+    init();
+  }
 
   function init() {
   const originalFetch = window.fetch.bind(window);
@@ -34,11 +38,28 @@ document.addEventListener('DOMContentLoaded', () => {
       location.reload();
     }
     return res;
-  };
+  }; 
+
+  if(sessionStorage.getItem('userRole')==='admin'){
+    document.getElementById('user-admin').classList.remove('hidden');
+    document.getElementById('create-user').addEventListener('click', async () => {
+      const u = document.getElementById('new-user').value.trim();
+      const p = document.getElementById('new-pass').value.trim();
+      const r = document.getElementById('new-role').value;
+      if(!u||!p) return;
+      await fetch('/api/admin/users', {
+        method:'POST',
+        headers:{'Content-Type':'application/json','x-session-token':sessionStorage.getItem('sessionToken')},
+        body: JSON.stringify({username:u,password:p,role:r})
+      });
+      alert('User created');
+    });
+  }
   // Tabs for switching between editor and question management
   const editorBtn = document.getElementById('btn-editor');
   const questionsBtn = document.getElementById('btn-questions');
   const archiveBtn = document.getElementById('btn-archive');
+  const exportBtn = document.getElementById('btn-export');
 
   const openCountSpan = document.getElementById('open-count');
 
@@ -95,6 +116,24 @@ document.addEventListener('DOMContentLoaded', () => {
   editorBtn.addEventListener('click', showEditor);
   questionsBtn.addEventListener('click', showQuestions);
   archiveBtn.addEventListener('click', showArchive);
+  exportBtn.addEventListener('click', async () => {
+    const res = await fetch('/api/admin/export', { headers: { 'x-session-token': sessionStorage.getItem('sessionToken') }});
+    if(res.ok){
+      const data = await res.json();
+      const blob = new Blob([JSON.stringify(data,null,2)], {type:'application/json'});
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'export.json';
+      a.click();
+      URL.revokeObjectURL(url);
+      const statsRes = await fetch('/api/admin/stats', { headers: { 'x-session-token': sessionStorage.getItem('sessionToken') }});
+      if(statsRes.ok){
+        const s = await statsRes.json();
+        alert('Gesamt:'+s.total); // simple stats display
+      }
+    }
+  });
 
   // Question management logic (copied from public/admin/index.html)
   const tabOpen = document.getElementById('tab-open');
@@ -229,7 +268,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const listEl = document.getElementById('headline-list');
   const searchEl = document.getElementById('search');
-  const quill = new Quill('#editor', { theme: 'snow', modules: { toolbar: '#quill-toolbar' } });
+  const quill = new Quill('#editor', {
+    theme: 'snow',
+    modules: {
+      toolbar: '#quill-toolbar',
+      table: true,
+      syntax: true
+    }
+  });
   const addBtn = document.getElementById('add-heading');
   const pane = document.getElementById('editor-pane');
   const archiveList = document.getElementById('archive-list');
@@ -276,7 +322,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function loadHeadlines() {
     try {
-      const res = await fetch('/api/admin/headlines', {
+      const q = encodeURIComponent(searchEl.value.trim());
+      const res = await fetch('/api/admin/headlines?q='+q, {
         headers: {
           'x-session-token': sessionStorage.getItem('sessionToken'),
           'Content-Type': 'application/json'
@@ -462,7 +509,8 @@ document.addEventListener('DOMContentLoaded', () => {
       diffBtn.addEventListener('click', () => {
         const active = allHeadlines.find(h => h.headline === e.headline);
         const current = active ? active.text : '';
-        alert(diffText(current, e.text));
+        const w = window.open('', '_blank');
+        w.document.body.innerHTML = diffText(current, e.text);
       });
       div.appendChild(btn);
       div.appendChild(diffBtn);
@@ -471,27 +519,18 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function diffText(a,b){
-    const aW=a.split(/\s+/); const bW=b.split(/\s+/);
-    const len=Math.max(aW.length,bW.length); const out=[];
-    for(let i=0;i<len;i++){
-      if(aW[i]===bW[i]) out.push(aW[i]||'');
-      else {
-        if(aW[i]) out.push('[-'+aW[i]+'-]');
-        if(bW[i]) out.push('[+'+bW[i]+'+]');
-      }
-    }
-    return out.join(' ');
+    const dmp = new diff_match_patch();
+    const diffs = dmp.diff_main(a,b);
+    dmp.diff_cleanupSemantic(diffs);
+    return diffs.map(d=>{
+      if(d[0]===0) return d[1];
+      if(d[0]===-1) return '<del>'+d[1]+'</del>';
+      return '<ins>'+d[1]+'</ins>';
+    }).join('');
   }
 
 
-  searchEl.addEventListener('input', () => {
-    const q = searchEl.value.toLowerCase();
-    const filtered = allHeadlines.filter(h =>
-      h.headline.toLowerCase().includes(q) ||
-      (h.text && h.text.toLowerCase().includes(q))
-    );
-    renderHeadlines(filtered);
-  });
+  searchEl.addEventListener('input', () => { loadHeadlines(); });
 
   archiveSearch.addEventListener('input', renderArchive);
   archiveSort.addEventListener('change', renderArchive);

--- a/public/admin2/index.html
+++ b/public/admin2/index.html
@@ -7,6 +7,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
   <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/quill-table-ui@1.0.2/dist/index.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/diff-match-patch@1.0.5/index.js"></script>
   <script defer src="admin.js"></script>
 </head>
 <body class="bg-gray-100 flex flex-col h-screen">
@@ -26,6 +28,7 @@
     </button>
 
     <button id="btn-archive" class="px-4 py-2 bg-gray-200 rounded">Archiv</button>
+    <button id="btn-export" class="px-4 py-2 bg-gray-200 rounded">Export</button>
   </div>
 
   <!-- Editor View -->
@@ -56,7 +59,21 @@
 
     <!-- Right Content Area: Text Editor (80%) -->
     <div id="editor-pane" class="w-4/5 flex flex-col">
-      <div id="quill-toolbar" class="p-2 bg-white border-b border-gray-200"></div>
+      <div id="quill-toolbar" class="p-2 bg-white border-b border-gray-200">
+        <span class="ql-formats">
+          <select class="ql-header"></select>
+          <button class="ql-bold"></button>
+          <button class="ql-italic"></button>
+          <button class="ql-underline"></button>
+        </span>
+        <span class="ql-formats">
+          <button class="ql-list" value="ordered"></button>
+          <button class="ql-list" value="bullet"></button>
+          <button class="ql-image"></button>
+          <button class="ql-code-block"></button>
+          <button class="ql-table"></button>
+        </span>
+      </div>
       <!-- Editor name and headline -->
       <div class="p-4 bg-white border-b border-gray-200 flex space-x-2">
         <input id="editor-name" class="p-2 border border-gray-300 rounded w-1/3" placeholder="Name">
@@ -91,6 +108,17 @@
       </select>
     </div>
     <div id="archive-list" class="space-y-4"></div>
+  </div>
+
+  <div id="user-admin" class="hidden p-4 space-y-2">
+    <h2 class="font-semibold">Benutzer anlegen</h2>
+    <input id="new-user" class="border p-2" placeholder="Username">
+    <input id="new-pass" type="password" class="border p-2" placeholder="Password">
+    <select id="new-role" class="border p-2">
+      <option value="editor">Editor</option>
+      <option value="admin">Admin</option>
+    </select>
+    <button id="create-user" class="px-2 py-1 bg-blue-500 text-white rounded">Anlegen</button>
   </div>
 
 


### PR DESCRIPTION
## Summary
- enhance authentication with roles and ability to create new users
- add session expiry logic
- expand Quill editor toolbar with image, code and table support
- improve diff view with diff-match-patch and open in new window
- provide export button and simple stats
- allow searching headlines on server via query

## Testing
- `npm -s test` *(fails: no tests defined)*
- `node --check server.cjs`
- `node --check controllers/authController.cjs`
- `node --check public/admin2/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_686025536c7c832b810bfb1c37018cc8