### PR TITLE
Fix admin button actions

### DIFF
--- a/public/admin2/admin.js
+++ b/public/admin2/admin.js
@@ -290,6 +290,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const activeCheckbox = document.getElementById('active-toggle');
   const saveBtn = document.getElementById('save-btn');
   const deleteBtn = document.getElementById('delete-btn');
+  deleteBtn.disabled = true;
 
   let currentId = null;
   let allHeadlines = [];
@@ -338,6 +339,7 @@ document.addEventListener('DOMContentLoaded', () => {
       editorNameInput.value = entry.editor || '';
       quill.root.innerHTML = entry.text;
       activeCheckbox.checked = !!entry.active;
+      deleteBtn.disabled = false;
     } catch (err) {
       console.error('Failed to load entry', err);
     }
@@ -350,7 +352,10 @@ document.addEventListener('DOMContentLoaded', () => {
       active: activeCheckbox.checked,
       editor: editorNameInput.value.trim()
     };
-    if (!payload.headline || !payload.text) return;
+    if (!payload.headline || !payload.text) {
+      alert('\u00dcberschrift und Text werden benötigt');
+      return;
+    }
     try {
       let res;
       if (currentId) {
@@ -376,15 +381,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const data = await res.json();
         currentId = data.id;
         await loadHeadlines();
+        deleteBtn.disabled = false;
         alert('Gespeichert');
       }
     } catch (err) {
       console.error('Failed to save entry', err);
+      alert('Speichern fehlgeschlagen');
     }
   }
 
   async function deleteEntry() {
     if (!currentId) return;
+    if (!confirm('Eintrag wirklich löschen?')) return;
     try {
       const res = await fetch(`/api/admin/entries/${currentId}`, {
         method: 'DELETE',
@@ -399,11 +407,13 @@ document.addEventListener('DOMContentLoaded', () => {
         editorNameInput.value = '';
         quill.root.innerHTML = '';
         activeCheckbox.checked = false;
+        deleteBtn.disabled = true;
         await loadHeadlines();
         alert('Gelöscht');
       }
     } catch (err) {
       console.error('Failed to delete entry', err);
+      alert('Löschen fehlgeschlagen');
     }
   }
 
@@ -415,6 +425,7 @@ document.addEventListener('DOMContentLoaded', () => {
     editorNameInput.value = '';
     quill.root.innerHTML = '';
     activeCheckbox.checked = true;
+    deleteBtn.disabled = true;
   });
 
   async function loadArchive() {

--- a/public/admin2/index.html
+++ b/public/admin2/index.html
@@ -86,8 +86,8 @@
           <input id="active-toggle" type="checkbox">
           <span>Active</span>
         </label>
-        <button id="delete-btn" class="px-3 py-2 bg-red-500 text-white rounded">Delete</button>
-        <button id="save-btn" class="px-3 py-2 bg-blue-500 text-white rounded">Save</button>
+        <button id="delete-btn" type="button" class="px-3 py-2 bg-red-500 text-white rounded">Delete</button>
+        <button id="save-btn" type="button" class="px-3 py-2 bg-blue-500 text-white rounded">Save</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- enable admin save/delete buttons with proper `type` attributes
- disable delete button until an entry is loaded and manage it via JS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68602e9706f8832babc37e51b6dca021