### PR TITLE
Fix admin JS parse error

### DIFF
--- a/public/admin2/admin.js
+++ b/public/admin2/admin.js
@@ -447,8 +447,6 @@ document.addEventListener('DOMContentLoaded', () => {
       w.document.write(`<h1>${entry.headline}</h1>` + entry.text);
     } catch (err) {
       console.error('Preview failed', err);
-=======
-
     }
   }
 


### PR DESCRIPTION
## Summary
- remove stray conflict marker from admin JS to allow script execution

## Testing
- `npm test` *(fails: Missing script; network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686044016b68832bbedf84f554cab794