### PR TITLE
Fix editor cleanup and improve heading button

### DIFF
--- a/public/admin2/admin.js
+++ b/public/admin2/admin.js
@@ -352,7 +352,8 @@ document.addEventListener('DOMContentLoaded', () => {
       currentId = entry.id;
       headlineInput.value = entry.headline;
       editorNameInput.value = entry.editor || '';
-      quill.root.innerHTML = entry.text;
+      // Use Quill API to properly insert HTML
+      quill.clipboard.dangerouslyPasteHTML(entry.text);
       activeCheckbox.checked = !!entry.active;
       deleteBtn.disabled = false;
     } catch (err) {
@@ -398,6 +399,9 @@ document.addEventListener('DOMContentLoaded', () => {
         await loadHeadlines();
         deleteBtn.disabled = false;
         alert('Gespeichert');
+      } else {
+        const msg = await res.text().catch(() => res.statusText);
+        alert('Speichern fehlgeschlagen: ' + msg);
       }
     } catch (err) {
       console.error('Failed to save entry', err);
@@ -420,11 +424,14 @@ document.addEventListener('DOMContentLoaded', () => {
         currentId = null;
         headlineInput.value = '';
         editorNameInput.value = '';
-        quill.root.innerHTML = '';
+        quill.setText('');
         activeCheckbox.checked = false;
         deleteBtn.disabled = true;
         await loadHeadlines();
         alert('Gelöscht');
+      } else {
+        const msg = await res.text().catch(() => res.statusText);
+        alert('Löschen fehlgeschlagen: ' + msg);
       }
     } catch (err) {
       console.error('Failed to delete entry', err);
@@ -456,9 +463,10 @@ document.addEventListener('DOMContentLoaded', () => {
     currentId = null;
     headlineInput.value = '';
     editorNameInput.value = '';
-    quill.root.innerHTML = '';
+    quill.setText('');
     activeCheckbox.checked = true;
     deleteBtn.disabled = true;
+    headlineInput.focus();
   });
 
   async function loadArchive() {

--- a/public/admin2/index.html
+++ b/public/admin2/index.html
@@ -52,7 +52,7 @@
       <!-- Add Heading Button -->
       <div class="p-4 border-t border-gray-200">
         <button id="add-heading" class="w-full px-3 py-2 border border-gray-300 rounded-md bg-blue-500 text-white hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500">
-          Add Heading
+          New Heading
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- reset Quill editor with API methods so entries clear correctly
- rename Add Heading button text to "New Heading"

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860450ab190832b84dc3fbc4407471e