### PR TITLE
Add export format popup

### DIFF
--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -89,6 +89,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   const questionsBtn = document.getElementById('btn-questions');
   const archiveBtn = document.getElementById('btn-archive');
   const exportBtn = document.getElementById('btn-export');
+  const exportModal = document.getElementById('export-modal');
+  const exportJsonBtn = document.getElementById('export-json');
+  const exportPdfBtn = document.getElementById('export-pdf');
+  const exportCancelBtn = document.getElementById('export-cancel');
   const logoutBtn = document.getElementById('btn-logout');
   const openCountSpan = document.getElementById('open-count');
   const editorView = document.getElementById('editor-view');
@@ -144,23 +148,48 @@ document.addEventListener('DOMContentLoaded', async () => {
   editorBtn.addEventListener('click', showEditor);
   questionsBtn.addEventListener('click', showQuestions);
   archiveBtn.addEventListener('click', showArchive);
-  exportBtn.addEventListener('click', async () => {
+  exportBtn.addEventListener('click', () => {
+    exportModal.classList.remove('hidden');
+  });
+
+  exportCancelBtn.addEventListener('click', () => {
+    exportModal.classList.add('hidden');
+  });
+
+  exportJsonBtn.addEventListener('click', () => handleExport('json'));
+  exportPdfBtn.addEventListener('click', () => handleExport('pdf'));
+
+  async function handleExport(type) {
+    exportModal.classList.add('hidden');
     try {
-      console.log('Exporting data...');
+      console.log('Exporting data...', type);
       const data = await fetchAndParse('/api/export');
-      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'export.json';
-      a.click();
-      URL.revokeObjectURL(url);
+      if (type === 'pdf') {
+        if (!window.jspdf) {
+          alert('PDF Export nicht verf\u00fcgbar');
+          return;
+        }
+        const { jsPDF } = window.jspdf;
+        const doc = new jsPDF();
+        const text = JSON.stringify(data, null, 2);
+        const lines = doc.splitTextToSize(text, 180);
+        doc.text(lines, 10, 10);
+        doc.save('export.pdf');
+      } else {
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'export.json';
+        a.click();
+        URL.revokeObjectURL(url);
+      }
       const stats = await fetchAndParse('/api/stats');
       alert('Gesamt: ' + stats.total);
     } catch (err) {
       console.error('Export error:', err);
     }
-  });
+  }
 
   logoutBtn.addEventListener('click', async () => {
     try {

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="/admin/toastui/toastui-editor.css" rel="stylesheet">
   <script src="/admin/toastui/toastui-editor.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script defer src="/admin/admin.js"></script>
   <link rel="icon" href="/favicon.ico">
 </head>
@@ -93,6 +94,18 @@
       <option value="admin">Admin</option>
     </select>
     <button id="create-user" class="px-2 py-1 bg-blue-500 text-white rounded">Anlegen</button>
+  </div>
+
+  <!-- Export Modal -->
+  <div id="export-modal" class="hidden fixed inset-0 bg-gray-500 bg-opacity-50 flex items-center justify-center z-50">
+    <div class="bg-white p-4 rounded shadow">
+      <p class="mb-4">Welches Format möchten Sie exportieren?</p>
+      <div class="flex justify-end space-x-2">
+        <button id="export-json" class="px-3 py-1 bg-blue-500 text-white rounded">JSON</button>
+        <button id="export-pdf" class="px-3 py-1 bg-blue-500 text-white rounded">PDF</button>
+        <button id="export-cancel" class="px-3 py-1 bg-gray-300 rounded">Abbrechen</button>
+      </div>
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add jsPDF for client-side PDF generation
- implement popup asking for export type
- support JSON or PDF download

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68610261ee5c832bb86817756bd27240