### PR TITLE
Add ai_input directory for FAQs

### DIFF
--- a/ai_input/README.md
+++ b/ai_input/README.md
@@ -1,0 +1,1 @@
+`faq.txt` stores answered questions in the format F:, A:, and E: lines. Edit via the admin interface.

--- a/public/admin/admin.js
+++ b/public/admin/admin.js
@@ -217,6 +217,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     tabAnswered.classList.remove('bg-blue-600', 'text-white');
     tabAnswered.classList.add('bg-gray-200');
     tabOpen.classList.remove('bg-gray-200');
+    loadOpen();
   }
 
   function showAnswered() {
@@ -227,6 +228,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     tabOpen.classList.remove('bg-blue-600', 'text-white');
     tabOpen.classList.add('bg-gray-200');
     tabAnswered.classList.remove('bg-gray-200');
+    loadAnswered();
   }
 
   tabOpen.addEventListener('click', showOpen);
@@ -275,6 +277,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             if (resp.ok) {
               div.remove();
               updateOpenCount(Math.max(0, parseInt(openCountSpan.textContent) - 1));
+              loadAnswered();
             } else {
               console.error('Answer submission failed:', await resp.json());
             }


### PR DESCRIPTION
## Summary
- add `ai_input/faq.txt` for storing answered questions
- document format in `ai_input/README.md`
- refresh answered list after updating questions

## Testing
- `node --check public/admin/admin.js`
- `ls -l ai_input`


------
https://chatgpt.com/codex/tasks/task_e_686132925f28832b9ac3c087c56858bb