### PR TITLE
Add deletion for unanswered questions

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -70,6 +70,9 @@
       <button id="tab-open" class="px-4 py-2 bg-blue-600 text-white rounded">Offene Fragen</button>
       <button id="tab-answered" class="px-4 py-2 bg-gray-200 rounded">Bereits beantwortete Fragen</button>
     </div>
+    <div class="mb-2">
+      <button id="delete-selected" class="px-3 py-1 bg-red-500 text-white rounded hidden">Ausgewählte löschen</button>
+    </div>
     <div id="open-list" class="space-y-4"></div>
     <div id="answered-list" class="space-y-4 hidden"></div>
   </div>


### PR DESCRIPTION
## Summary
- allow deleting unanswered questions via new `/api/unanswered` DELETE endpoint
- add trash buttons and checkbox selection to remove questions in admin UI

## Testing
- `node --check controllers/adminController.cjs`
- `node --check public/admin/admin.js`
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6861686f1228832bbc50559e38c94c7d